### PR TITLE
climate: экспонировать заслонку забора воздуха как preset_mode

### DIFF
--- a/components/tion/climate/__init__.py
+++ b/components/tion/climate/__init__.py
@@ -10,6 +10,7 @@ TionClimate = tion_ns.class_("TionClimate", climate.Climate, cg.Component)
 CONF_ENABLE_HEAT_COOL = "enable_heat_cool"
 CONF_ENABLE_FAN_AUTO = "enable_fan_auto"
 CONF_ENABLE_FAN_OFF = "enable_fan_off"
+CONF_ENABLE_AIR_INTAKE_PRESET = "enable_air_intake_preset"
 
 PC = new_pc(None)
 
@@ -20,6 +21,7 @@ CONFIG_SCHEMA = PC.climate_schema(
         cv.Optional(CONF_ENABLE_HEAT_COOL): cv.boolean,
         cv.Optional(CONF_ENABLE_FAN_AUTO): cv.boolean,
         cv.Optional(CONF_ENABLE_FAN_OFF): cv.boolean,
+        cv.Optional(CONF_ENABLE_AIR_INTAKE_PRESET): cv.boolean,
     },
 )
 
@@ -29,3 +31,4 @@ async def to_code(config: dict):
     cgp.setup_value(config, CONF_ENABLE_HEAT_COOL, var.set_enable_heat_cool)
     cgp.setup_value(config, CONF_ENABLE_FAN_AUTO, var.set_enable_fan_auto)
     cgp.setup_value(config, CONF_ENABLE_FAN_OFF, var.set_enable_fan_off)
+    cgp.setup_value(config, CONF_ENABLE_AIR_INTAKE_PRESET, var.set_enable_air_intake_preset)

--- a/components/tion/climate/tion_climate.cpp
+++ b/components/tion/climate/tion_climate.cpp
@@ -8,6 +8,7 @@ namespace tion {
 static const char *const TAG = "tion_climate";
 
 constexpr static const auto FAN_MODE_LABELS = {"1", "2", "3", "4", "5", "6"};
+constexpr static const auto AIR_INTAKE_PRESETS = {"outdoor", "indoor", "mixed"};
 
 // ВАЖНО: fan_mode не должен быть nullptr
 inline uint8_t fan_mode_to_speed(const char *fan_mode) { return *fan_mode - '0'; }
@@ -96,7 +97,7 @@ climate::ClimateTraits TionClimate::traits() {
        i < max_fan_speed; i++) {
     fan_modes.push_back(speed_to_fan_mode(i + 1));
   }
-  traits.set_supported_custom_fan_modes(fan_modes);
+  this->set_supported_custom_fan_modes(fan_modes);
 
   if (this->parent_->api()->has_presets()) {
     std::vector<const char *> presets;
@@ -109,8 +110,10 @@ climate::ClimateTraits TionClimate::traits() {
       }
     }
     if (!presets.empty()) {
-      traits.set_supported_custom_presets(presets);
+      this->set_supported_custom_presets(presets);
     }
+  } else if (this->options_.enable_air_intake_preset && this->parent_->traits().supports_gate_position_change_mixed) {
+    this->set_supported_custom_presets(AIR_INTAKE_PRESETS);
   }
 
   traits.add_feature_flags(climate::CLIMATE_SUPPORTS_ACTION);
@@ -136,6 +139,17 @@ void TionClimate::control(const climate::ClimateCall &call) {
       const auto preset = call.get_custom_preset();
       TION_C_LOGD(TAG, "Set custom preset %s", preset);
       this->parent_->api()->enable_preset(preset.c_str(), tion);
+    }
+  } else if (this->options_.enable_air_intake_preset && call.has_custom_preset()) {
+    const auto preset = call.get_custom_preset();
+    size_t i = 0;
+    for (auto &&p : AIR_INTAKE_PRESETS) {
+      if (preset == p) {
+        TION_C_LOGD(TAG, "Set air intake preset %s", p);
+        tion->set_gate_position(static_cast<dentra::tion::TionGatePosition>(i));
+        break;
+      }
+      i++;
     }
   }
 
@@ -227,6 +241,14 @@ void TionClimate::on_state_(const TionState &state) {
       has_changes |= this->set_preset_(climate_preset);
     } else if (!this->has_custom_preset() || strcasecmp(this->get_custom_preset().c_str(), active_preset) != 0) {
       has_changes |= this->set_custom_preset_(active_preset);
+    }
+  } else if (this->options_.enable_air_intake_preset) {
+    const auto gate_position = static_cast<uint8_t>(state.gate_position);
+    if (gate_position < AIR_INTAKE_PRESETS.size()) {
+      const auto *active_preset = *(AIR_INTAKE_PRESETS.begin() + gate_position);
+      if (!this->has_custom_preset() || strcasecmp(this->get_custom_preset().c_str(), active_preset) != 0) {
+        has_changes |= this->set_custom_preset_(active_preset);
+      }
     }
   }
 

--- a/components/tion/climate/tion_climate.h
+++ b/components/tion/climate/tion_climate.h
@@ -28,12 +28,18 @@ class TionClimate : public EntityExtension<climate::Climate>, public Component, 
   void set_enable_heat_cool(bool enable_heat_cool) { this->options_.enable_heat_cool = enable_heat_cool; }
   void set_enable_fan_auto(bool enable_fan_auto) { this->options_.enable_fan_auto = enable_fan_auto; }
   void set_enable_fan_off(bool enable_fan_off) { this->options_.enable_fan_off = enable_fan_off; }
+  // экспонирует air_intake (заслонку) как preset_mode climate-сущности вместо/в дополнение к select.*_air_intake;
+  // несовместимо с реальными пресетами устройства (has_presets()) — при их наличии игнорируется
+  void set_enable_air_intake_preset(bool enable_air_intake_preset) {
+    this->options_.enable_air_intake_preset = enable_air_intake_preset;
+  }
 
  protected:
   struct {
     bool enable_heat_cool : 1;
     bool enable_fan_auto : 1;
     bool enable_fan_off : 1;
+    bool enable_air_intake_preset : 1;
   } options_{};
   void on_state_(const TionState &state);
   // важно this->mode уже должен быть выставлен в актуальное значение


### PR DESCRIPTION
## Что делает

Добавляет опцию `enable_air_intake_preset` для climate-сущности бризера. Когда включена, положение заслонки забора воздуха (`outdoor`/`indoor`/`mixed`, то же самое, что уже доступно через `select.*_air_intake`) становится доступно как `preset_mode` climate-сущности.

Зачем: стандартный more-info popup climate-сущности в Home Assistant не умеет показывать произвольные `select`-сущности — только жёстко заданный набор climate-специфичных фич (hvac mode, fan mode, preset mode, swing mode). Заслонку раньше можно было переключить только через отдельную карточку `select.*_air_intake` вне этого диалога. Теперь то же самое доступно прямо в popup климата, без второй карточки.

По умолчанию **выключено** (`enable_air_intake_preset: false`), обратной совместимости не нарушает.

## Ограничения

- Взаимоисключимо с реальными пресетами устройства (`api()->has_presets()`) — если у бризера сконфигурированы обычные пресеты (например, через `presets:` в YAML), заслонка в `preset_mode` не попадёт, приоритет у настоящих пресетов.
- Работает только если контроллер поддерживает `supports_gate_position_change_mixed` (3-позиционная заслонка).

## Побочное изменение

Заодно мигрировал файл с deprecated `ClimateTraits::set_supported_custom_fan_modes`/`set_supported_custom_presets` (удаляются в ESPHome 2026.11.0) на актуальный `Climate`-owned API (`this->set_supported_custom_fan_modes(...)`/`this->set_supported_custom_presets(...)`). Функционально идентично, просто убирает deprecation-warning при сборке на актуальном ESPHome.

## Тестирование

Проверено вживую на реальном устройстве Tion 3S (ESP32-C6, UART):
- Прошивка компилируется и заливается по OTA без ошибок.
- `climate.tion_3s_climate` в Home Assistant показывает `preset_modes: [outdoor, indoor, mixed]`.
- Переключение `preset_mode` через сервис `climate.set_preset_mode` реально двигает заслонку — синхронно отражается в `select.*_air_intake`.
- `fan_modes` (1-6) продолжают работать как раньше после миграции на новый API — регрессии не обнаружено.