### PR TITLE
sensor: уточнить именование и иконку датчиков температуры (intake/supply)

### DIFF
--- a/components/tion/sensor/__init__.py
+++ b/components/tion/sensor/__init__.py
@@ -51,7 +51,11 @@ PC = new_pc(
         "current_temperature": {
             CONF_DEVICE_CLASS: DEVICE_CLASS_TEMPERATURE,
             CONF_STATE_CLASS: STATE_CLASS_MEASUREMENT,
-            CONF_ICON: cgp.ICON_HOME_THERMOMETER,
+            # This is the SUPPLY air temperature (air leaving the unit, after the
+            # heater) - NOT a room/indoor sensor. The unit has no room probe.
+            # Use a neutral icon instead of mdi:home-thermometer, which falsely
+            # implies a room temperature.
+            CONF_ICON: "mdi:thermometer-lines",
             CONF_UNIT_OF_MEASUREMENT: UNIT_CELSIUS,
             CONF_ACCURACY_DECIMALS: 0,
         },
@@ -173,6 +177,14 @@ PC = new_pc(
         "speed": "fan_speed",
         "indoor_temperature": "current_temperature",
         "fan_max_speed": "max_fan_speed",
+        # HVAC airflow-oriented aliases (non-breaking, more accurate naming):
+        # the unit measures air at the intake (outdoor side) and the supply
+        # (after the heater), there is no room/indoor probe.
+        "intake_temperature": "outdoor_temperature",
+        "inlet_temperature": "outdoor_temperature",
+        "supply_temperature": "current_temperature",
+        "outlet_temperature": "current_temperature",
+        "discharge_temperature": "current_temperature",
     }
 )
 


### PR DESCRIPTION
## Что делает

`current_temperature` — это температура SUPPLY-воздуха (на выходе из бризера, после нагревателя), а не комнатная/indoor. У устройства вообще нет комнатного зонда. Старая иконка `mdi:home-thermometer` создавала ложное впечатление, что это датчик в помещении — заменил на нейтральный `mdi:thermometer-lines`.

Заодно добавил алиасы, ориентированные на HVAC-терминологию воздушного потока, вместо внутреннего деления `outdoor`/`current`:
- `intake_temperature` / `inlet_temperature` → `outdoor_temperature`
- `supply_temperature` / `outlet_temperature` / `discharge_temperature` → `current_temperature`

Позволяет пользователям при конфигурации сенсоров называть их так, как физически называется точка измерения (забор/выход воздуха), а не путаться в internal-имёнах `outdoor`/`current`, которые не всем очевидны без чтения исходников.

## Совместимость

Чисто аддитивное изменение — новые алиасы, старые имена (`outdoor_temperature`, `current_temperature`) продолжают работать без изменений. Меняется только иконка у `current_temperature` (визуальное, не влияет на entity_id/поведение).